### PR TITLE
setting `maxVertexCount = vertices.size() / 3`

### DIFF
--- a/VK_KHR_ray_tracing/VK_KHR_ray_tracing.cpp
+++ b/VK_KHR_ray_tracing/VK_KHR_ray_tracing.cpp
@@ -615,7 +615,7 @@ int main() {
         accelerationCreateGeometryInfo.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
         accelerationCreateGeometryInfo.maxPrimitiveCount = indices.size() / 3;
         accelerationCreateGeometryInfo.indexType = VK_INDEX_TYPE_UINT32;
-        accelerationCreateGeometryInfo.maxVertexCount = vertices.size();
+        accelerationCreateGeometryInfo.maxVertexCount = vertices.size() / 3;
         accelerationCreateGeometryInfo.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
         accelerationCreateGeometryInfo.allowsTransforms = VK_FALSE;
 


### PR DESCRIPTION
This is not fixing an error, but we are paying attention to the small details, aren't we?
Therefore, I propose to set the `maxVertexCount`  to `vertices.size() / 3` instead of `vertices.size()`. The former yields `3` in this particular case, while the latter yields `9`. We only require `3` vertices, each of which is in the format `VK_FORMAT_R32G32B32_SFLOAT`.